### PR TITLE
New file organisation

### DIFF
--- a/BattTimeWidget.10s.sh
+++ b/BattTimeWidget.10s.sh
@@ -7,11 +7,11 @@
 # <bitbar.desc>Wrapper for battstat, developped originally by http://www.github.com/imwally</bitbar.desc>
 # <bitbar.image>http://www.imgur.com/</bitbar.image>
 # <bitbar.dependencies>none</bitbar.dependencies>
-# <bitbar.abouturl>http://github.com/Thibaulltt/hello-world</bitbar.abouturl>
+# <bitbar.abouturl>http://github.com/Thibaulltt/BattTimeWidget</bitbar.abouturl>
 
 # Get info for widget & dropdown menu
-rem=`./dependencies/battstat {t}`
-per=`./dependencies/battstat {p}`
+rem=`battstat {t}`
+per=`battstat {p}`
 # Get charging status from pmset(1)
 pmset1=`pmset -g adapter | head -1 | tail -1`
 pmset2=`pmset -g adapter | head -2 | tail -1`
@@ -55,7 +55,6 @@ else
 	fi
 fi
 echo "Percentage = $per"
-
 # --------------------------------
 # Get charging/not charging status
 # --------------------------------

--- a/battstat
+++ b/battstat
@@ -1,0 +1,200 @@
+#!/usr/bin/env sh
+
+charging_icon="⚡"     #  U+26A1 - Thunderbolt
+discharging_icon="🔋" # U+1F50B - Battery
+
+print_help() {
+    echo "usage: battstat [options] format"
+    echo ""
+    echo "options:"
+    echo "    -h, --help                display help information"
+    echo "    -c, --charging-icon       string to display in icon's place when battery is charging"
+    echo "    -d, --discharging-icon    string to display in icon's place when battery is discharging"
+    echo "    --percent-when-charged    only display percent when charged"
+    echo ""
+    echo "format:"
+    echo "    {i}    display icon"
+    echo "    {t}    display time remaining"
+    echo "    {p}    display percent"
+    echo ""
+    echo "    Note: There must be a space between each format token."
+}
+
+exit_no_battery() {
+    echo "battstat: no battery found"
+    exit 1
+}
+
+get_darwin_details() {
+    battery_details=$(pmset -g batt)
+
+    # Exit if no battery exists.
+    if ! echo "$battery_details" | grep -q InternalBattery; then
+	exit_no_battery
+    fi
+    
+    charged=$(echo "$battery_details" | grep -w 'charged')
+    charging=$(echo "$battery_details" | grep -w 'AC Power')
+    discharging=$(echo "$battery_details" | grep -w 'Battery Power')
+    time=$(echo "$battery_details" | grep 'InternalBattery' | awk '{print $5}' | grep '^[0-9]')
+    percent=$(echo "$battery_details" | grep 'InternalBattery' | awk '{print $3}')
+    percent=${percent%?} # Strips the last character (;)
+}
+
+get_linux_details() {
+    battery_details=$(upower -i $(upower -e | grep 'BAT'))
+    
+    # Exit if no batery exists.
+    if [ -z "$battery_details" ]; then
+	exit_no_battery
+    fi
+    
+    charged=$(echo "$battery_details" | grep 'state' | grep -w 'fully-charged')
+    charging=$(echo "$battery_details" | grep 'state' | grep -w 'charging')
+    discharging=$(echo "$battery_details" | grep 'state' | grep -w 'discharging')
+    percent=$(echo "$battery_details"| grep 'percentage' | awk '{print $2}')
+    
+    case $(echo "$battery_details" | grep 'time' | awk '{print $5}') in
+	"hours")
+	    hours=$(echo "$battery_details" | grep 'time' | awk '{print $4}' | cut -d . -f1)
+	    minutes=$(echo "$battery_details" | grep 'time' | awk '{print $4}' | cut -d . -f2)
+	    minutes=$(echo .$minutes \* 60 | bc -l | cut -d. -f1)
+	    ;;
+	"minutes")
+	    minutes=$(echo "$battery_details" | grep 'time' | awk '{print $4}' | cut -d . -f1)
+	    ;;
+    esac
+
+    # Diplay 0 in the hours spot when only minutes remain.
+    if [ -z "$hours" ]; then
+	hours="0"
+    fi
+
+    # Prefix 0 when minutes drop below 10.
+    if [ $(printf "%s" $minutes | wc -c) -eq '1' ]; then
+	minutes="0$minutes"
+    fi
+    
+    time=$hours:$minutes
+}
+
+get_openbsd_details() {
+    battery_details=$(apm)
+
+    # Exit if no battery exists.
+    if [ -z "$battery_details" ]; then
+	exit_no_battery
+    fi
+
+    charged=$(echo $battery_details | grep '100%')
+    charging=$(echo $battery_details | grep -w 'state: connected')
+    discharging=$(echo $battery_details | grep -w 'state: not connected')
+    percent=$(echo $battery_details | grep 'Battery state' | awk '{print $4}')
+    full_minutes=$(echo $battery_details | grep 'Battery state' | awk '{print $6}')
+    hours=$(echo $(($full_minutes/60)))
+    minutes=$(echo $(($full_minutes%60)))
+
+    # Prefix 0 when minutes drop below 10.
+    if [ $(printf "%s" $minutes | wc -c) -eq '1' ]; then
+	minutes="0$minutes"
+    fi
+        
+    time=$hours:$minutes
+}
+
+hide_percent_until_charged() {
+    if [ -z "$charged" ]; then
+	percent=""
+    fi
+}   
+
+print_icon() {
+    if [ ! -z "$charging" ] || [ ! -z "$charged" ]; then
+	icon=$charging_icon
+    elif [ ! -z "$discharging" ]; then
+	icon=$discharging_icon
+    fi
+
+    printf " %s " $icon
+}
+
+print_time() {
+    # Display "calc..." when calculating time remaining.
+    if [ -z "$time" ] || [ $time = "0:00" ]; then
+	time="calc..."
+    fi
+
+    # When fully charged, we still want the time displayed
+    if [ ! -z "$charged" ]; then
+	time="0:00"
+    fi
+    
+    if [ ! -z "$time" ]; then
+	printf " %s " $time
+    fi
+
+}
+
+print_percent() {
+    if [ ! -z "$percent" ]; then
+	printf " %s " $percent
+    fi
+}
+
+if [ $# -eq 0 ] || [ $1 = "-h" ] || [ $1 = "--help" ]; then
+    print_help
+    exit 0
+fi
+
+case $(uname) in
+    "Darwin")
+	get_darwin_details
+	;;
+    "Linux")
+	get_linux_details
+	;;
+    "OpenBSD")
+	get_openbsd_details
+	;;
+    *)
+	echo "battstat: operating system not supported"
+	exit 1
+	;;
+esac
+
+while test $# -gt 0; do
+    case "$1" in
+	--percent-when-charged)
+	    hide_percent_until_charged
+	    shift
+	    ;;
+	-c|--charging-icon)
+	    charging_icon="$2"
+	    shift
+	    shift
+	    ;;
+	-d|--discharging-icon)
+	    discharging_icon="$2"
+	    shift
+	    shift
+	    ;;
+	{i})
+	    print_icon
+	    shift
+	    ;;
+	{t})
+	    print_time
+	    shift
+	    ;;
+	{p})
+	    print_percent
+	    shift
+	    ;;
+	*)
+	    print_help
+	    break
+	    ;;
+    esac
+done
+
+printf "\n"

--- a/install
+++ b/install
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if test $# == 1
+then
+	cp BattTimeWidget.10s.sh $1
+	cp -r dependencies $1
+	ln $1/dependencies/battstat /usr/local/bin
+else
+	echo " Path not recognized.\n Usage : \n install <path to bitbar plugins folder>"
+fi


### PR DESCRIPTION
Added an install script (**install**).
The install script allows the user to specify his *BitBar* plugin folders, and copies the given files into the plugin folder.
The install script also links the `battstat` utility into `/usr/local/bin`, which is both in the regular `PATH` and accessible without needing `sudo` to run `ln`as administrator.